### PR TITLE
fix  (void-variable restclient-response-mode-map)

### DIFF
--- a/restclient-jq.el
+++ b/restclient-jq.el
@@ -76,7 +76,7 @@ ARGS contains the variable name and a jq pattern to use."
  "Set a restclient variable with the value jq expression,
 takes var & jq expression as args.
 eg. -> jq-set-var :my-token .token")
-(define-key restclient-response-mode-map  (kbd "C-c C-j") #'restclient-jq-interactive-result)
+(define-key restclient-response-buffer-map (kbd "C-c C-j") #'restclient-jq-interactive-result)
 
 (provide 'restclient-jq)
 

--- a/restclient.el
+++ b/restclient.el
@@ -26,6 +26,13 @@
 (require 'outline)
 (require 'view)
 (require 'compat)
+
+(unless (fboundp 'hash-table-contains-p)
+  (defsubst hash-table-contains-p (key table)
+    "Return non-nil if TABLE has an element with KEY."
+    (let ((missing (make-symbol "missing")))
+      (not (eq (gethash key table missing) missing)))))
+
 (eval-when-compile (require 'subr-x))
 (eval-when-compile
   (if (version< emacs-version "26")
@@ -315,9 +322,9 @@ Workaround for Emacs bug#61916"
 
 (defmacro restclient--pop-global-var (var)
   "Restore old global value of VAR, if any."
-  `(when (and (hash-table-contains-p ',var restclient--globals-stack)
-              (< 0 (length (gethash ',var restclient--globals-stack))))
-     (setq ,var (pop (gethash ',var restclient--globals-stack)))))
+  `(when (and (hash-table-contains-p ,var restclient--globals-stack)
+              (< 0 (length (gethash ,var restclient--globals-stack))))
+     (setq ,var (pop (gethash ,var restclient--globals-stack)))))
 
 (defun restclient-http-do (method url headers entity &rest handle-args)
   "Send ENTITY and HEADERS to URL as a METHOD request."


### PR DESCRIPTION
- Older versions of restclient used `restclient-response-mode-map` as the name.
- Your version uses `restclient-response-buffer-map`.
- Fix hash table error, fixes #2 
-  add customizable response buffer mode 
introduce restclient-response-buffer-mode-override alist to allow users
to specify major modes for specific content types or magic matches in
REST responses (e.g., use 'json-mode for JSON data)
prior guessing logic is retained as fallback
also refactor code for improved indentation and consistency
fix xml pretty-print regex (">[ \\t]*<") and handle mode selection for json/xml
includes indentation and whitespace consistency improvements throughout the file