### PR TITLE
Remove trailing whitespace from table headings

### DIFF
--- a/restclient.el
+++ b/restclient.el
@@ -1102,7 +1102,7 @@ Optional argument SUPPRESS-RESPONSE-BUFFER do not display response buffer if t."
 		(var-row (var-name var-value)
 		  (insert "|" (sanitize-name-cell var-name) "|" (sanitize-value-cell var-value) "|\n"))
 		(var-table (table-name)
-		  (insert (format "* %s \n|--|\n|Name|Value|\n|---|\n" table-name)))
+		  (insert (format "* %s\n|--|\n|Name|Value|\n|---|\n" table-name)))
 		(var-table-footer ()
 		  (insert "|--|\n\n")))
 


### PR DESCRIPTION
I have `show-trailing-whitespace` enabled, and when I use `restclient-show-info` the table headings have visible trailing whitespace. This small fix removes the trailing whitespace from the headings.
