### PR TITLE
Implement restclient-enable-eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ response.
 
 # In-buffer variables
 
+For safety, this functionality is disabled by default. Set `restclient-enable-eval` to non-nil to use it.
+
 You declare a variable like this:
 
     :myvar = the value
@@ -390,6 +392,12 @@ __Default: t__
 
 Determines if the response buffer should be put in view-mode or left
 editable.
+
+### restclient-enable-eval
+
+__Default: nil__
+
+Allows evaluation of arbitrary forms in file when non-nil. Never set this when working with untrusted files.
 
 # Known issues
 


### PR DESCRIPTION
restclient.el is unsafe to use on files from untrusted sources because it evaluates code by default.

This commit disables evaluation by default. It can be re-enabled by setting restclient-enable-eval to t.

Adapted from Phil Hagelberg's [original patch](https://git.sr.ht/~technomancy/restclient.el/commit/85ba4dba675a395bb74983ff9acb7060bd1a2333).

Fixes #8 