### PR TITLE
Add support for QUERY HTTP method

### DIFF
--- a/restclient.el
+++ b/restclient.el
@@ -289,7 +289,7 @@ Stored as an alist of name -> (hook-creation-func . description)")
 (defconst restclient-empty-line-regexp "^\\s-*$")
 
 (defconst restclient-method-url-regexp
-  "^[[:blank:]]*\\(GET\\|POST\\|DELETE\\|PUT\\|HEAD\\|OPTIONS\\|PATCH\\|PROPFIND\\) \\(.*\\)$")
+  "^[[:blank:]]*\\(GET\\|POST\\|DELETE\\|PUT\\|HEAD\\|OPTIONS\\|PATCH\\|PROPFIND\\|QUERY\\) \\(.*\\)$")
 
 (defconst restclient-url-continuation-line-regexp
   "^[[:blank:]]+\\(.*\\)$")


### PR DESCRIPTION
Update regex in restclient-method-url-regexp to include QUERY as avalid HTTP method following RFC 10008 standard.

https://www.rfc-editor.org/info/rfc10008/

## test details

I carried out the following checks.

### emacs side

```
QUERY http://localhost:8081/foo?apple=2&orange=3
Content-Type: application/json

{
  "data": 1
}
```
### server side

```
bash-5.2$ nc -l 8081
QUERY /foo?apple=2&orange=3 HTTP/1.1
MIME-Version: 1.0
Connection: keep-alive
Host: localhost:8081
Accept-charset: utf-8;q=1, gb2312;q=0.5, iso-8859-1;q=0.5, big5;q=0.5, iso-2022-jp;q=0.5, shift_jis;q=0.5, euc-tw;q=0.5, euc-jp;q=0.5, euc-jis-2004;q=0.5, euc-kr;q=0.5, us-ascii;q=0.5, utf-7;q=0.5, hz-gb-2312;q=0.5, big5-hkscs;q=0.5, gbk;q=0.5, gb18030;q=0.5, iso-8859-5;q=0.5, koi8-r;q=0.5, koi8-u;q=0.5, cp866;q=0.5, koi8-t;q=0.5, windows-1251;q=0.5, cp855;q=0.5, iso-8859-2;q=0.5, iso-8859-3;q=0.5, iso-8859-4;q=0.5, iso-8859-9;q=0.5, iso-8859-10;q=0.5, iso-8859-13;q=0.5, iso-8859-14;q=0.5, iso-8859-15;q=0.5, windows-1250;q=0.5, windows-1252;q=0.5, windows-1254;q=0.5, windows-1257;q=0.5, cp775;q=0.5, cp850;q=0.5, cp852;q=0.5, cp857;q=0.5, cp858;q=0.5, cp860;q=0.5, cp861;q=0.5, cp863;q=0.5, cp865;q=0.5, cp437;q=0.5, macintosh;q=0.5, next;q=0.5, hp-roman8;q=0.5, adobe-standard-encoding;q=0.5, iso-8859-16;q=0.5, iso-8859-7;q=0.5, windows-1253;q=0.5, cp737;q=0.5, cp851;q=0.5, cp869;q=0.5, iso-8859-8;q=0.5, windows-1255;q=0.5, cp862;q=0.5, iso-2022-jp-2004;q=0.5, cp874;q=0.5, iso-8859-11;q=0.5, viscii;q=0.5, windows-1258;q=0.5, iso-8859-6;q=0.5, windows-1256;q=0.5, iso-2022-cn;q=0.5, iso-2022-cn-ext;q=0.5, iso-2022-jp-2;q=0.5, iso-2022-kr;q=0.5, utf-16le;q=0.5, utf-16be;q=0.5, utf-16;q=0.5, x-ctext;q=0.5
Accept: */*
Content-Type: application/json
Content-length: 15

{
  "data": 1
}
```

The following data was sent from `nc` back to Emacs.

```
HTTP/1.1 200 OK



```

The `*HTTP Response*` buffer displays the following data.

```
// QUERY http://localhost:8081/foo?apple=2&orange=3
// HTTP/1.1 200 OK
// Request duration: 12.131020s

```
